### PR TITLE
Make PostgreSQL data reproducible during E2E tests

### DIFF
--- a/db/20-dump.sh
+++ b/db/20-dump.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+mkdir -p /var/lib/postgresql/data/dumps
+pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" --clean -f /var/lib/postgresql/data/dumps/mock.sql

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,3 @@
 FROM postgres:17.4
 
-COPY 00-init.sql /docker-entrypoint-initdb.d/
-COPY 10-mock.sql /docker-entrypoint-initdb.d/
+COPY . /docker-entrypoint-initdb.d/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "bcrypt": "^5.1.1",
         "connect-redis": "^8.0.3",
+        "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-session": "^1.18.1",
         "on-headers": "^1.0.2",
@@ -5419,6 +5420,18 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dset": {
       "version": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "bcrypt": "^5.1.1",
     "connect-redis": "^8.0.3",
+    "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-session": "^1.18.1",
     "on-headers": "^1.0.2",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -18,7 +18,7 @@ export default defineConfig({
         },
         {
             name: 'chromium',
-            use: { ...devices['Desktop Chrome'] },
+            use: devices['Desktop Chrome'],
             dependencies: ['setup db'],
         },
         {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
     use: {
@@ -10,4 +10,20 @@ export default defineConfig({
     reporter: 'line',
     testMatch: 'www/tests/e2e/**/*.spec.ts',
     workers: 1,
+    projects: [
+        {
+            name: 'setup db',
+            testMatch: 'www/tests/e2e/global.setup.ts',
+            teardown: 'cleanup db',
+        },
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+            dependencies: ['setup db'],
+        },
+        {
+            name: 'cleanup db',
+            testMatch: 'www/tests/e2e/global.teardown.ts',
+        },
+    ],
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -9,4 +9,5 @@ export default defineConfig({
     },
     reporter: 'line',
     testMatch: 'www/tests/e2e/**/*.spec.ts',
+    workers: 1,
 });

--- a/www/tests/e2e/db-utils.ts
+++ b/www/tests/e2e/db-utils.ts
@@ -5,19 +5,20 @@ import { promisify } from 'node:util';
 const execAsync = promisify(exec);
 const dumpsDir = '/var/lib/postgresql/data/dumps';
 
-const user = process.env.POSTGRES_USER;
-if (user === undefined) {
+const user = process.env.POSTGRES_USER ?? '';
+if (user === '') {
     throw new Error('Missing POSTGRES_USER env variable');
 }
-const db = process.env.POSTGRES_DB;
-if (db === undefined) {
+
+const db = process.env.POSTGRES_DB ?? '';
+if (db === '') {
     throw new Error('Missing POSTGRES_DB env variable');
 }
 
 export async function dumpDb(fileName = 'dump.sql') {
-    await execAsync(`docker compose exec postgres pg_dump -U ${user!} ${db!} --clean -f ${dumpsDir}/${fileName}`);
+    await execAsync(`docker compose exec postgres pg_dump -U ${user} ${db} --clean -f "${dumpsDir}/${fileName}"`);
 }
 
 export async function restoreDb(fileName = 'dump.sql') {
-    await execAsync(`docker compose exec postgres psql -U ${user!} ${db!} -f ${dumpsDir}/${fileName} -q`);
+    await execAsync(`docker compose exec postgres psql -U ${user} ${db} -f "${dumpsDir}/${fileName}" -q`);
 }

--- a/www/tests/e2e/db-utils.ts
+++ b/www/tests/e2e/db-utils.ts
@@ -1,0 +1,23 @@
+import 'dotenv/config';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execAsync = promisify(exec);
+const dumpsDir = '/var/lib/postgresql/data/dumps';
+
+const user = process.env.POSTGRES_USER;
+if (user === undefined) {
+    throw new Error('Missing POSTGRES_USER env variable');
+}
+const db = process.env.POSTGRES_DB;
+if (db === undefined) {
+    throw new Error('Missing POSTGRES_DB env variable');
+}
+
+export async function dumpDb(fileName = 'dump.sql') {
+    await execAsync(`docker compose exec postgres pg_dump -U ${user!} ${db!} --clean -f ${dumpsDir}/${fileName}`);
+}
+
+export async function restoreDb(fileName = 'dump.sql') {
+    await execAsync(`docker compose exec postgres psql -U ${user!} ${db!} -f ${dumpsDir}/${fileName} -q`);
+}

--- a/www/tests/e2e/fixtures.ts
+++ b/www/tests/e2e/fixtures.ts
@@ -1,4 +1,5 @@
 import { test as base } from '@playwright/test';
+import { restoreDb } from './db-utils';
 
 declare global {
     interface Window {
@@ -19,6 +20,7 @@ export const test = base.extend({
             }
         });
 
+        await restoreDb('mock.sql');
         await use(page);
     },
 });

--- a/www/tests/e2e/global.setup.ts
+++ b/www/tests/e2e/global.setup.ts
@@ -1,0 +1,7 @@
+import { test as setup } from '@playwright/test';
+import { dumpDb } from './db-utils';
+
+setup('Reset database to mock data', async () => {
+    // This will be run once before all tests (all files)
+    await dumpDb('setup.sql');
+});

--- a/www/tests/e2e/global.setup.ts
+++ b/www/tests/e2e/global.setup.ts
@@ -1,7 +1,7 @@
 import { test as setup } from '@playwright/test';
 import { dumpDb } from './db-utils';
 
-setup('Reset database to mock data', async () => {
+setup('Save database before running tests', async () => {
     // This will be run once before all tests (all files)
     await dumpDb('setup.sql');
 });

--- a/www/tests/e2e/global.teardown.ts
+++ b/www/tests/e2e/global.teardown.ts
@@ -1,0 +1,7 @@
+import { test as teardown } from '@playwright/test';
+import { restoreDb } from './db-utils';
+
+teardown('Restore database from before tests', async () => {
+    // This will be run once all tests are finished (from all files)
+    await restoreDb('setup.sql');
+});

--- a/www/tests/e2e/index.spec.ts
+++ b/www/tests/e2e/index.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'playwright/test';
-import { test } from './test-setup';
+import { test } from './fixtures';
 
 test('Can switch languages', async ({ page }) => {
     await page.goto('/');

--- a/www/tests/e2e/login.spec.ts
+++ b/www/tests/e2e/login.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { test } from './test-setup';
+import { test } from './fixtures';
 
 test('Can sign in and logout', async ({ page }) => {
     await page.goto('/');

--- a/www/tests/e2e/semesters.spec.ts
+++ b/www/tests/e2e/semesters.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'playwright/test';
-import { test } from './test-setup';
+import { test } from './fixtures';
 
 test('Can access semesters from /', async ({ page }) => {
     await page.goto('/');


### PR DESCRIPTION
Closes #63 

This MR makes all E2E tests start with the same data in the database, making tests that modify the database possible. Here is a list of changes:
- test parallelism is disabled, by limiting Playwright to 1 worker process in the config
- `db/20-dump.sh` was added, which dumps the database data after inserting the mock data
- `global.setup.ts` and `global.teardown.ts` were added, which save the database state before any tests run and restore it once they all finish. This ensures developers keep their current data they might have while working on the app.
- The database is reset to the mock data dump before each test (page fixture in `fixutres.ts`)

To dump the database data, [pg_dump](https://www.postgresql.org/docs/17/app-pgdump.html) is used which outputs an SQL file, that can then be run with `psql`.