### PR TITLE
Improve modal forms

### DIFF
--- a/www/src/components/Modal.vue
+++ b/www/src/components/Modal.vue
@@ -40,6 +40,19 @@ onBeforeUnmount(() => {
         window.bootstrap.Modal.getOrCreateInstance(el.value).dispose();
     }
 });
+
+function shownHandler() {
+    emit('shown');
+
+    if (!el.value) {
+        return;
+    }
+
+    const autoFocusInput = el.value.querySelector('input[autofocus]');
+    if (autoFocusInput instanceof HTMLInputElement) {
+        autoFocusInput.focus();
+    }
+}
 </script>
 
 <template>
@@ -56,7 +69,7 @@ onBeforeUnmount(() => {
                 'hide.bs.modal': () => emit('hide'),
                 'hidden.bs.modal': () => emit('hidden'),
                 'show.bs.modal': () => emit('show'),
-                'shown.bs.modal': () => emit('shown'),
+                'shown.bs.modal': shownHandler,
             }"
         >
             <div

--- a/www/src/components/exercises/AddExercise.vue
+++ b/www/src/components/exercises/AddExercise.vue
@@ -10,6 +10,7 @@ defineProps<{
     semester: SemesterData;
     subject: SubjectData;
     classrooms: ClassroomData[];
+    nextExerciseNumber: number;
 }>();
 
 const translations = {
@@ -38,7 +39,12 @@ function translate(text: keyof (typeof translations)[LangId]): string {
             <template #header>
                 {{ translate('Add new exercise') }}
             </template>
-            <ExerciseForm :semester="semester" :subject="subject" :classrooms="classrooms" />
+            <ExerciseForm
+                :exercise="{ exerciseNumber: nextExerciseNumber }"
+                :semester="semester"
+                :subject="subject"
+                :classrooms="classrooms"
+            />
         </Modal>
     </div>
 </template>

--- a/www/src/components/exercises/ExerciseForm.vue
+++ b/www/src/components/exercises/ExerciseForm.vue
@@ -101,7 +101,7 @@ function translate(text: keyof (typeof translations)[LangId]): string {
 
         <div>
             <label for="exerciseNumber" class="form-label">{{ translate('Exercise number') }}</label>
-            <input id="exerciseNumber" v-model="exerciseNumber" type="number" class="form-control" required />
+            <input id="exerciseNumber" v-model="exerciseNumber" type="number" :min="1" class="form-control" required />
         </div>
 
         <div>

--- a/www/src/components/exercises/ExerciseForm.vue
+++ b/www/src/components/exercises/ExerciseForm.vue
@@ -101,7 +101,7 @@ function translate(text: keyof (typeof translations)[LangId]): string {
 
         <div>
             <label for="exerciseNumber" class="form-label">{{ translate('Exercise number') }}</label>
-            <input id="exerciseNumber" v-model="exerciseNumber" type="number" :min="1" class="form-control" required />
+            <input id="exerciseNumber" v-model="exerciseNumber" type="number" :min="0" class="form-control" required />
         </div>
 
         <div>

--- a/www/src/components/exercises/ExerciseForm.vue
+++ b/www/src/components/exercises/ExerciseForm.vue
@@ -9,11 +9,11 @@ import type { SubjectData } from '@components/subjects/types';
 const props = defineProps<{
     semester: SemesterData;
     subject: SubjectData;
-    exercise?: ExerciseData;
+    exercise?: Partial<ExerciseData>;
     classrooms: ClassroomData[];
 }>();
 
-const isEditing = computed(() => props.exercise !== undefined);
+const isEditing = computed(() => props.exercise?.id !== undefined);
 
 const addingFailed = ref(false);
 

--- a/www/src/components/exercises/ExerciseForm.vue
+++ b/www/src/components/exercises/ExerciseForm.vue
@@ -96,7 +96,7 @@ function translate(text: keyof (typeof translations)[LangId]): string {
     <form class="vstack gap-3 mx-auto" style="max-width: 500px" @submit.prevent="submit">
         <div>
             <label for="exerciseName" class="form-label">{{ translate('Exercise name') }}</label>
-            <input id="exerciseName" v-model="exerciseName" type="text" class="form-control" required />
+            <input id="exerciseName" v-model="exerciseName" type="text" class="form-control" required autofocus />
         </div>
 
         <div>

--- a/www/src/components/subjects/AddSubject.vue
+++ b/www/src/components/subjects/AddSubject.vue
@@ -2,7 +2,7 @@
 import { langId } from '@components/frontend/lang';
 import type { SemesterData } from '@components/semesters/types';
 import Modal from '@components/Modal.vue';
-import SubjectFrom from '@components/subjects/SubjectFrom.vue';
+import SubjectForm from '@components/subjects/SubjectForm.vue';
 
 defineProps<{
     semester: SemesterData;
@@ -34,7 +34,7 @@ function translate(text: keyof (typeof translations)[LangId]): string {
             <template #header>
                 {{ translate('Add new subject') }}
             </template>
-            <SubjectFrom :semester="semester" />
+            <SubjectForm :semester="semester" />
         </Modal>
     </div>
 </template>

--- a/www/src/components/subjects/EditSubject.vue
+++ b/www/src/components/subjects/EditSubject.vue
@@ -4,7 +4,7 @@ import type { SemesterData } from '@components/semesters/types';
 import type { SubjectData } from '@components/subjects/types';
 import IconButton from '@components/IconButton.vue';
 import Modal from '@components/Modal.vue';
-import SubjectFrom from '@components/subjects/SubjectFrom.vue';
+import SubjectForm from '@components/subjects/SubjectForm.vue';
 
 const props = defineProps<{
     semester: SemesterData;
@@ -40,6 +40,6 @@ const modalId = `edit-subject-modal-${props.semester.slug}-${props.subject.slug}
 
     <Modal :id="modalId">
         <template #header>{{ translate('Edit Subject') }} {{ subject.name }}</template>
-        <SubjectFrom :semester="semester" :subject="subject" />
+        <SubjectForm :semester="semester" :subject="subject" />
     </Modal>
 </template>

--- a/www/src/components/subjects/SubjectForm.vue
+++ b/www/src/components/subjects/SubjectForm.vue
@@ -83,7 +83,7 @@ function translate(text: keyof (typeof translations)[LangId]): string {
     <form class="vstack gap-3 mx-auto" style="max-width: 500px" @submit.prevent="submit">
         <div>
             <label for="subjectName" class="form-label">{{ translate('Subject name') }}</label>
-            <input id="subjectName" v-model="subjectName" type="text" class="form-control" required />
+            <input id="subjectName" v-model="subjectName" type="text" class="form-control" required autofocus />
         </div>
 
         <div class="text-center">

--- a/www/src/pages/semesters/[semesterSlug]/[subjectSlug]/index.astro
+++ b/www/src/pages/semesters/[semesterSlug]/[subjectSlug]/index.astro
@@ -64,7 +64,7 @@ const subjectData: SubjectData = {
 };
 
 const exercises = await Exercise.fetchAllFromSubject(subject);
-const nextExerciseNumber = exercises.map(e => e.exerciseNumber).reduce((max, num) => Math.max(max, num), 0) + 1;
+const nextExerciseNumber = exercises.reduce((max, e) => Math.max(max, e.exerciseNumber), 0) + 1;
 
 const classrooms = await Classroom.fetchAll();
 

--- a/www/src/pages/semesters/[semesterSlug]/[subjectSlug]/index.astro
+++ b/www/src/pages/semesters/[semesterSlug]/[subjectSlug]/index.astro
@@ -64,6 +64,7 @@ const subjectData: SubjectData = {
 };
 
 const exercises = await Exercise.fetchAllFromSubject(subject);
+const nextExerciseNumber = exercises.map(e => e.exerciseNumber).reduce((max, num) => Math.max(max, num), 0) + 1;
 
 const classrooms = await Classroom.fetchAll();
 
@@ -101,6 +102,7 @@ const classroomsData: ClassroomData[] = classrooms.map(classroom => ({
                     semester={semesterData}
                     subject={subjectData}
                     classrooms={classroomsData}
+                    nextExerciseNumber={nextExerciseNumber}
                 />
             )
         }

--- a/www/src/pages/semesters/api/exercises.ts
+++ b/www/src/pages/semesters/api/exercises.ts
@@ -6,7 +6,7 @@ import { Subject } from '@backend/subject';
 
 const schema = z.object({
     name: z.string().trim().nonempty(),
-    exerciseNumber: z.number(),
+    exerciseNumber: z.number().int().min(1),
     subjectId: z.uuid(),
     classroomId: z.uuid(),
 });

--- a/www/src/pages/semesters/api/exercises.ts
+++ b/www/src/pages/semesters/api/exercises.ts
@@ -6,7 +6,7 @@ import { Subject } from '@backend/subject';
 
 const schema = z.object({
     name: z.string().trim().nonempty(),
-    exerciseNumber: z.number().int().min(1),
+    exerciseNumber: z.number().int().min(0),
     subjectId: z.uuid(),
     classroomId: z.uuid(),
 });


### PR DESCRIPTION
This MR brings a couple changes to our modal forms:
- the exercise number in the `AddExercise` modal is autofilled based on existing exercises
- the exercise number needs to be at least 1, before it accepted negative values
- fixed typo `SubjectFrom` -> `SubjectForm`
- the first text input in the `SubjectForm` and `ExerciseForm` is now autofocused when opening the modal