### PR TITLE
Add API utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@types/on-headers": "^1.0.4",
         "@types/pg": "^8.15.5",
         "@vitest/eslint-plugin": "^1.3.4",
+        "@vueuse/core": "^13.7.0",
         "astro": "^5.13.2",
         "eslint": "^9.33.0",
         "eslint-config-prettier": "^10.1.8",
@@ -3103,6 +3104,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.39.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
@@ -3912,6 +3920,47 @@
       "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.7.0.tgz",
+      "integrity": "sha512-myagn09+c6BmS6yHc1gTwwsdZilAovHslMjyykmZH3JNyzI5HoWhv114IIdytXiPipdHJ2gDUx0PB93jRduJYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "13.7.0",
+        "@vueuse/shared": "13.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.7.0.tgz",
+      "integrity": "sha512-8okFhS/1ite8EwUdZZfvTYowNTfXmVCOrBFlA31O0HD8HKXhY+WtTRyF0LwbpJfoFPc+s9anNJIXMVrvP7UTZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.7.0.tgz",
+      "integrity": "sha512-Wi2LpJi4UA9kM0OZ0FCZslACp92HlVNw1KPaDY6RAzvQ+J1s7seOtcOpmkfbD5aBSmMn9NvOakc8ZxMxmDXTIg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/on-headers": "^1.0.4",
     "@types/pg": "^8.15.5",
     "@vitest/eslint-plugin": "^1.3.4",
+    "@vueuse/core": "^13.7.0",
     "astro": "^5.13.2",
     "eslint": "^9.33.0",
     "eslint-config-prettier": "^10.1.8",

--- a/www/src/components/LoginForm.vue
+++ b/www/src/components/LoginForm.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { langId } from '@components/frontend/lang';
+import { apiPost } from '@components/api';
 
 const { nextPage } = defineProps<{
     nextPage: string;
@@ -12,32 +13,20 @@ const password = ref<string>('');
 const loginFailed = ref<boolean>(false);
 
 async function submit() {
-    try {
-        const result = await fetch('/api/login/', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                email: email.value.trim(),
-                password: password.value,
-            }),
-        });
+    const loginSuccess = await apiPost<boolean>('/api/login/', {
+        email: email.value.trim(),
+        password: password.value,
+    });
 
-        if (!result.ok) {
-            console.error('API request failed!');
-            return;
-        }
+    if (loginSuccess === undefined) {
+        return;
+    }
 
-        const loginSuccess = (await result.json()) as boolean;
-        loginFailed.value = !loginSuccess;
-        password.value = '';
+    loginFailed.value = !loginSuccess;
+    password.value = '';
 
-        if (loginSuccess) {
-            window.location.href = nextPage;
-        }
-    } catch (error) {
-        console.log(error);
+    if (loginSuccess) {
+        window.location.href = nextPage;
     }
 }
 

--- a/www/src/components/LoginForm.vue
+++ b/www/src/components/LoginForm.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue';
 import { langId } from '@components/frontend/lang';
 import { apiPost } from '@components/api';
+import type { LoginApiData } from '@components/users/types';
 
 const { nextPage } = defineProps<{
     nextPage: string;
@@ -16,7 +17,7 @@ async function submit() {
     const loginSuccess = await apiPost<boolean>('/api/login/', {
         email: email.value.trim(),
         password: password.value,
-    });
+    } satisfies LoginApiData);
 
     if (loginSuccess === undefined) {
         return;

--- a/www/src/components/api.ts
+++ b/www/src/components/api.ts
@@ -1,0 +1,238 @@
+import { computed, isRef, type Ref, toValue } from 'vue';
+import { type MaybeRefOrGetter, useCloned, useFetch, type UseFetchOptions, type UseFetchReturn } from '@vueuse/core';
+
+type NonUndefined = NonNullable<unknown> | null;
+
+async function apiFetch<T extends NonUndefined = NonUndefined>(
+    input: string | URL | Request,
+    init?: RequestInit,
+): Promise<NoInfer<T> | undefined> {
+    const response = await fetch(input, init).catch((error: unknown) => {
+        console.error(`API: fetch failed with error:\n`, error);
+        return undefined;
+    });
+
+    if (!response) {
+        return undefined;
+    }
+
+    if (!response.ok) {
+        console.error(`API: request failed with status ${response.status} ${response.statusText}\n`, response);
+        return undefined;
+    }
+
+    return (await response.json().catch((error: unknown) => {
+        console.error(`API: failed to parse response body\n`, error);
+        return undefined;
+    })) as T | undefined;
+}
+
+function prepareUrl(resource: string | URL, params?: URLSearchParams): URL {
+    const url = new URL(resource, document.baseURI);
+
+    if (params !== undefined) {
+        for (const [paramName, paramValue] of params.entries()) {
+            url.searchParams.append(paramName, paramValue);
+        }
+    }
+
+    return url;
+}
+
+/** Makes a GET requrest to the API and returns `undefined` if there was en error. */
+export async function apiGet<T extends NonUndefined = NonUndefined>(
+    resource: string | URL,
+    params?: URLSearchParams,
+): Promise<NoInfer<T> | undefined> {
+    const url = prepareUrl(resource, params);
+
+    return await apiFetch<T>(url);
+}
+
+function parseApiArgs(resource: string | URL, arg1: NonUndefined, arg2: unknown) {
+    // Determine arguments based on their count and types for different signatures
+    let params: URLSearchParams | undefined;
+    if (arg2 !== undefined) {
+        if (!(arg1 instanceof URLSearchParams)) {
+            throw new Error('Invalid params argument');
+        }
+
+        params = arg1;
+    }
+
+    const body = arg2 !== undefined ? arg2 : arg1;
+
+    const url = prepareUrl(resource, params);
+
+    if (body instanceof FormData) {
+        return {
+            url,
+            body,
+            headers: {
+                // The Content-Type header will be set by the browser with the correct boundary value
+                // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest_API/Using_FormData_Objects#sending_files_using_a_formdata_object
+            },
+        };
+    } else if (body instanceof URLSearchParams) {
+        return {
+            url,
+            body,
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+        };
+    } else {
+        return {
+            url,
+            body: JSON.stringify(body),
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        };
+    }
+}
+
+/** Makes a POST requrest to the API and returns `undefined` if there was en error. */
+export async function apiPost<T extends NonUndefined = NonUndefined>(
+    resource: string | URL,
+    body: NonUndefined,
+): Promise<NoInfer<T> | undefined>;
+
+/** Makes a POST requrest to the API and returns `undefined` if there was en error. */
+export async function apiPost<T extends NonUndefined = NonUndefined>(
+    resource: string | URL,
+    params: URLSearchParams,
+    body: NonUndefined,
+): Promise<NoInfer<T> | undefined>;
+
+/** Makes a POST requrest to the API and returns `undefined` if there was en error. */
+export async function apiPost<T extends NonUndefined = NonUndefined>(
+    resource: string | URL,
+    arg1: NonUndefined,
+    arg2?: unknown,
+): Promise<NoInfer<T> | undefined> {
+    const { url, body, headers } = parseApiArgs(resource, arg1, arg2);
+
+    return await apiFetch<T>(url, {
+        method: 'POST',
+        headers,
+        body,
+    });
+}
+
+/** Makes a PATCH requrest to the API and returns `undefined` if there was en error. */
+export async function apiPatch<T extends NonUndefined = NonUndefined>(
+    resource: string | URL,
+    body: NonUndefined,
+): Promise<NoInfer<T> | undefined>;
+
+/** Makes a PATCH requrest to the API and returns `undefined` if there was en error. */
+export async function apiPatch<T extends NonUndefined = NonUndefined>(
+    resource: string | URL,
+    params: URLSearchParams,
+    body: NonUndefined,
+): Promise<NoInfer<T> | undefined>;
+
+/** Makes a PATCH requrest to the API and returns `undefined` if there was en error. */
+export async function apiPatch<T extends NonUndefined = NonUndefined>(
+    resource: string | URL,
+    arg1: NonUndefined,
+    arg2?: unknown,
+): Promise<NoInfer<T> | undefined> {
+    const { url, body, headers } = parseApiArgs(resource, arg1, arg2);
+
+    return await apiFetch<T>(url, {
+        method: 'PATCH',
+        headers,
+        body,
+    });
+}
+
+interface UseApiFetchCommonOptions extends UseFetchOptions {
+    resetDataOnError?: boolean;
+}
+
+export interface UseApiFetchNotClonedOptions extends UseApiFetchCommonOptions {
+    /** Returns the data as a cloned `Ref` instead of a `ShallowRef`. Useful for optimistic updates. */
+    clone?: false;
+}
+
+export interface UseApiFetchClonedOptions extends UseApiFetchCommonOptions {
+    /** Returns the data as a cloned `Ref` instead of a `ShallowRef`. Useful for optimistic updates. */
+    clone: true;
+}
+
+export type UseApiFetchOptions = UseApiFetchNotClonedOptions | UseApiFetchClonedOptions;
+
+export interface UseFetchReturnCloned<T> extends UseFetchReturn<T> {
+    data: Ref<T | null, T | null>;
+}
+
+export type UseApiFetchReturnNonCloned<T> = UseFetchReturn<T> & PromiseLike<UseFetchReturn<T>>;
+
+export type UseApiFetchReturnCloned<T> = UseFetchReturnCloned<T> & PromiseLike<UseFetchReturnCloned<T>>;
+
+export type UseApiFetchReturn<T> = UseApiFetchReturnNonCloned<T> | UseApiFetchReturnCloned<T>;
+
+export function useApiFetch<T>(
+    url: MaybeRefOrGetter<string | URL>,
+    params: MaybeRefOrGetter<URLSearchParams>,
+    useFetchOptions?: UseApiFetchNotClonedOptions,
+): UseApiFetchReturnNonCloned<T>;
+
+export function useApiFetch<T>(
+    url: MaybeRefOrGetter<string | URL>,
+    params: MaybeRefOrGetter<URLSearchParams>,
+    useFetchOptions?: UseApiFetchClonedOptions,
+): UseApiFetchReturnCloned<T>;
+
+export function useApiFetch<T>(
+    url: MaybeRefOrGetter<string | URL>,
+    useFetchOptions?: UseApiFetchNotClonedOptions,
+): UseApiFetchReturnNonCloned<T>;
+
+export function useApiFetch<T>(
+    url: MaybeRefOrGetter<string | URL>,
+    useFetchOptions?: UseApiFetchClonedOptions,
+): UseApiFetchReturnCloned<T>;
+
+export function useApiFetch<T>(
+    url: MaybeRefOrGetter<string | URL>,
+    arg1?: MaybeRefOrGetter<URLSearchParams> | UseApiFetchOptions,
+    arg2?: UseApiFetchOptions,
+): UseApiFetchReturn<T> {
+    const { params, options } =
+        isRef(arg1) || typeof arg1 === 'function' || arg1 instanceof URLSearchParams
+            ? { params: arg1, options: arg2 }
+            : { options: arg1 };
+
+    const result: UseApiFetchReturn<T> = useFetch(
+        computed(() => prepareUrl(toValue(url), toValue(params)).toString()),
+        {
+            refetch: true,
+            updateDataOnError: options?.resetDataOnError === true,
+            onFetchError(ctx) {
+                const isAbortError = ctx.error instanceof DOMException && ctx.error.name === 'AbortError';
+
+                if (!isAbortError) {
+                    console.error(`API: fetch failed with error:\n`, ctx.error);
+                }
+
+                if (options?.resetDataOnError === true) {
+                    ctx.data = null;
+                }
+
+                return ctx;
+            },
+            ...options,
+        },
+    ).json<T>();
+
+    if (options?.clone === true) {
+        const { cloned } = useCloned(result.data);
+
+        result.data = cloned;
+    }
+
+    return result;
+}

--- a/www/src/components/classrooms/ClassroomForm.vue
+++ b/www/src/components/classrooms/ClassroomForm.vue
@@ -2,7 +2,7 @@
 import { ref } from 'vue';
 import { langId } from '@components/frontend/lang';
 import { apiPatch, apiPost } from '@components/api';
-import type { ClassroomData } from '@components/classrooms/types';
+import type { ClassroomCreateApiData, ClassroomData, ClassroomEditApiData } from '@components/classrooms/types';
 
 const props = defineProps<{
     classroom?: ClassroomData;
@@ -10,13 +10,16 @@ const props = defineProps<{
 
 const submitFailed = ref(false);
 
-const name = ref<string | undefined>(props.classroom?.name);
+const name = ref<string>(props.classroom?.name ?? '');
 
 async function submit() {
     const success =
         props.classroom === undefined
-            ? await apiPost<boolean>('/classrooms/api/', { name: name.value })
-            : await apiPatch<boolean>('/classrooms/api/', { id: props.classroom.id, name: name.value });
+            ? await apiPost<boolean>('/classrooms/api/', { name: name.value } satisfies ClassroomCreateApiData)
+            : await apiPatch<boolean>('/classrooms/api/', {
+                  id: props.classroom.id,
+                  name: name.value,
+              } satisfies ClassroomEditApiData);
 
     if (success === undefined) {
         return;

--- a/www/src/components/classrooms/types.ts
+++ b/www/src/components/classrooms/types.ts
@@ -1,4 +1,19 @@
+import z from 'zod';
+
 export interface ClassroomData {
     id: string;
     name: string;
 }
+
+export const classroomCreateApiSchema = z.object({
+    name: z.string().trim().nonempty(),
+});
+
+export type ClassroomCreateApiData = z.input<typeof classroomCreateApiSchema>;
+
+export const classroomEditApiSchema = z.object({
+    id: z.uuid(),
+    name: z.string().trim().nonempty().optional(),
+});
+
+export type ClassroomEditApiData = z.input<typeof classroomEditApiSchema>;

--- a/www/src/components/exercises/ExerciseForm.vue
+++ b/www/src/components/exercises/ExerciseForm.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { langId } from '@components/frontend/lang';
+import { apiPatch, apiPost } from '@components/api';
 import type { ClassroomData } from '@components/classrooms/types';
 import type { ExerciseData } from '@components/exercises/types';
 import type { SemesterData } from '@components/semesters/types';
@@ -17,7 +18,7 @@ const props = defineProps<{
 
 const isEditing = computed(() => props.exercise?.id !== undefined);
 
-const addingFailed = ref(false);
+const submitFailed = ref(false);
 
 const exerciseName = ref<string | undefined>(props.exercise?.name);
 const exerciseNumber = ref<number | undefined>(props.exercise?.exerciseNumber);
@@ -25,51 +26,33 @@ const exerciseClassroomId = ref<string | undefined>(props.exercise?.classroomId)
 const teacher = ref<UserData | null>(props.exercise?.teacher ?? props.subject.teachers[0] ?? null);
 
 async function submit() {
-    try {
-        const result = !isEditing.value
-            ? await fetch('/semesters/api/exercises/', {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({
-                      name: exerciseName.value,
-                      exerciseNumber: exerciseNumber.value,
-                      subjectId: props.subject.id,
-                      classroomId: exerciseClassroomId.value,
-                      teacherId: teacher.value?.id,
-                  }),
-              })
-            : await fetch('/semesters/api/exercises/', {
-                  method: 'PATCH',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({
-                      id: props.exercise?.id,
-                      name: exerciseName.value,
-                      exerciseNumber: exerciseNumber.value,
-                      classroomId: exerciseClassroomId.value,
-                      teacherId: teacher.value?.id,
-                  }),
-              });
+    const success = !isEditing.value
+        ? await apiPost<boolean>('/semesters/api/exercises/', {
+              name: exerciseName.value,
+              exerciseNumber: exerciseNumber.value,
+              subjectId: props.subject.id,
+              classroomId: exerciseClassroomId.value,
+              teacherId: teacher.value?.id,
+          })
+        : await apiPatch<boolean>('/semesters/api/exercises/', {
+              id: props.exercise?.id,
+              name: exerciseName.value,
+              exerciseNumber: exerciseNumber.value,
+              classroomId: exerciseClassroomId.value,
+              teacherId: teacher.value?.id,
+          });
 
-        if (!result.ok) {
-            console.error('API request failed!');
-            return;
+    submitFailed.value = !success;
+
+    if (success) {
+        const newUrl = `/semesters/${props.semester.slug}/${props.subject.slug}/${exerciseNumber.value}/`;
+
+        if (isEditing.value) {
+            window.history.replaceState({}, '', newUrl);
+            window.location.reload();
+        } else {
+            window.location.assign(newUrl);
         }
-
-        const addingSuccess = (await result.json()) as boolean;
-        addingFailed.value = !addingSuccess;
-
-        if (addingSuccess) {
-            const newUrl = `/semesters/${props.semester.slug}/${props.subject.slug}/${exerciseNumber.value}/`;
-
-            if (isEditing.value) {
-                window.history.replaceState({}, '', newUrl);
-                window.location.reload();
-            } else {
-                window.location.assign(newUrl);
-            }
-        }
-    } catch (error) {
-        console.log(error);
     }
 }
 
@@ -136,7 +119,7 @@ function translate(text: keyof (typeof translations)[LangId]): string {
             <button type="submit" class="btn btn-success">{{ translate(isEditing ? 'Save' : 'Add') }}</button>
         </div>
 
-        <div v-if="addingFailed" class="text-center text-danger">
+        <div v-if="submitFailed" class="text-center text-danger">
             {{ translate('Exercise with this name or number already exists.') }}
         </div>
     </form>

--- a/www/src/components/exercises/types.ts
+++ b/www/src/components/exercises/types.ts
@@ -1,3 +1,4 @@
+import z from 'zod';
 import type { UserData } from '@components/users/types';
 
 export interface ExerciseData {
@@ -8,3 +9,23 @@ export interface ExerciseData {
     classroomId: string;
     teacher: UserData;
 }
+
+export const exerciseCreateApiSchema = z.object({
+    name: z.string().trim().nonempty(),
+    exerciseNumber: z.number().int().min(0),
+    subjectId: z.uuid(),
+    classroomId: z.uuid(),
+    teacherId: z.uuid(),
+});
+
+export type ExerciseCreateApiData = z.input<typeof exerciseCreateApiSchema>;
+
+export const exerciseEditApiSchema = z.object({
+    id: z.uuid(),
+    name: z.string().optional(),
+    exerciseNumber: z.number().optional(),
+    classroomId: z.uuid().optional(),
+    teacherId: z.uuid().optional(),
+});
+
+export type ExerciseEditApiData = z.input<typeof exerciseEditApiSchema>;

--- a/www/src/components/semesters/SemesterForm.vue
+++ b/www/src/components/semesters/SemesterForm.vue
@@ -2,7 +2,7 @@
 import { ref } from 'vue';
 import { langId } from '@components/frontend/lang';
 import { apiPatch, apiPost } from '@components/api';
-import type { SemesterData } from '@components/semesters/types';
+import type { SemesterCreateApiData, SemesterData, SemesterEditApiData } from '@components/semesters/types';
 
 const props = defineProps<{
     semester?: SemesterData;
@@ -16,6 +16,15 @@ const startDate = ref<string | undefined>(props.semester?.startDate);
 const endDate = ref<string | undefined>(props.semester?.endDate);
 
 async function submit() {
+    if (
+        type.value === undefined ||
+        year.value === undefined ||
+        startDate.value === undefined ||
+        endDate.value === undefined
+    ) {
+        return;
+    }
+
     const success =
         props.semester === undefined
             ? await apiPost<boolean>('/semesters/api/semesters/', {
@@ -23,14 +32,18 @@ async function submit() {
                   year: year.value,
                   startDate: startDate.value,
                   endDate: endDate.value,
-              })
+              } satisfies SemesterCreateApiData)
             : await apiPatch<boolean>('/semesters/api/semesters/', {
                   id: props.semester.id,
                   type: type.value,
                   year: year.value,
                   startDate: startDate.value,
                   endDate: endDate.value,
-              });
+              } satisfies SemesterEditApiData);
+
+    if (success === undefined) {
+        return;
+    }
 
     submitFailed.value = !success;
 

--- a/www/src/components/semesters/types.ts
+++ b/www/src/components/semesters/types.ts
@@ -1,3 +1,4 @@
+import z from 'zod';
 import type { SemesterType } from '@backend/semester';
 
 export interface SemesterData {
@@ -8,3 +9,36 @@ export interface SemesterData {
     startDate: string;
     endDate: string;
 }
+
+export const semesterCreateApiSchema = z.object({
+    year: z.number(),
+    type: z.enum(['summer', 'winter']),
+    startDate: z.iso.date().transform(str => {
+        return new Date(`${str}T00:00:00`);
+    }),
+    endDate: z.iso.date().transform(str => {
+        return new Date(`${str}T00:00:00`);
+    }),
+});
+
+export type SemesterCreateApiData = z.input<typeof semesterCreateApiSchema>;
+
+export const semesterEditApiSchema = z.object({
+    id: z.uuid(),
+    year: z.number().optional(),
+    type: z.enum(['summer', 'winter']).optional(),
+    startDate: z.iso
+        .date()
+        .transform(str => {
+            return new Date(`${str}T00:00:00`);
+        })
+        .optional(),
+    endDate: z.iso
+        .date()
+        .transform(str => {
+            return new Date(`${str}T00:00:00`);
+        })
+        .optional(),
+});
+
+export type SemesterEditApiData = z.input<typeof semesterEditApiSchema>;

--- a/www/src/components/subjects/SubjectForm.vue
+++ b/www/src/components/subjects/SubjectForm.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { langId } from '@components/frontend/lang';
+import { apiPatch, apiPost } from '@components/api';
 import type { SemesterData } from '@components/semesters/types';
 import type { SubjectData } from '@components/subjects/types';
 import type { UserData } from '@components/users/types';
@@ -15,53 +16,35 @@ const props = defineProps<{
 
 const isEditing = computed(() => props.subject !== undefined);
 
-const addingFailed = ref(false);
+const submitFailed = ref(false);
 
 const subjectName = ref<string | undefined>(props.subject?.name);
 const teachers = ref<UserData[]>(props.subject?.teachers ?? []);
 
 async function submit() {
-    try {
-        const result = !isEditing.value
-            ? await fetch('/semesters/api/subjects/', {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({
-                      name: subjectName.value,
-                      semesterId: props.semester.id,
-                      teacherIds: teachers.value.map(user => user.id),
-                  }),
-              })
-            : await fetch('/semesters/api/subjects/', {
-                  method: 'PATCH',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({
-                      id: props.subject?.id,
-                      name: subjectName.value,
-                      teacherIds: teachers.value.map(user => user.id),
-                  }),
-              });
+    const success = !isEditing.value
+        ? await apiPost<boolean>('/semesters/api/subjects/', {
+              name: subjectName.value,
+              semesterId: props.semester.id,
+              teacherIds: teachers.value.map(user => user.id),
+          })
+        : await apiPatch<boolean>('/semesters/api/subjects/', {
+              id: props.subject?.id,
+              name: subjectName.value,
+              teacherIds: teachers.value.map(user => user.id),
+          });
 
-        if (!result.ok) {
-            console.error('API request failed!');
-            return;
+    submitFailed.value = !success;
+
+    if (success) {
+        const newUrl = `/semesters/${props.semester.slug}/${toHyphenatedLowercase(subjectName.value ?? '')}/`;
+
+        if (isEditing.value) {
+            window.history.replaceState({}, '', newUrl);
+            window.location.reload();
+        } else {
+            window.location.assign(newUrl);
         }
-
-        const addingSuccess = (await result.json()) as boolean;
-        addingFailed.value = !addingSuccess;
-
-        if (addingSuccess) {
-            const newUrl = `/semesters/${props.semester.slug}/${toHyphenatedLowercase(subjectName.value ?? '')}/`;
-
-            if (isEditing.value) {
-                window.history.replaceState({}, '', newUrl);
-                window.location.reload();
-            } else {
-                window.location.assign(newUrl);
-            }
-        }
-    } catch (error) {
-        console.log(error);
     }
 }
 
@@ -103,7 +86,7 @@ function translate(text: keyof (typeof translations)[LangId]): string {
             <button type="submit" class="btn btn-success">{{ translate(isEditing ? 'Save' : 'Add') }}</button>
         </div>
 
-        <div v-if="addingFailed" class="text-center text-danger">
+        <div v-if="submitFailed" class="text-center text-danger">
             {{ translate('Subject with this name already exists.') }}
         </div>
     </form>

--- a/www/src/components/subjects/types.ts
+++ b/www/src/components/subjects/types.ts
@@ -1,3 +1,4 @@
+import z from 'zod';
 import type { UserData } from '@components/users/types';
 
 export interface SubjectData {
@@ -7,3 +8,19 @@ export interface SubjectData {
     slug: string;
     teachers: UserData[];
 }
+
+export const subjectCreateApiSchema = z.object({
+    name: z.string().trim().nonempty(),
+    semesterId: z.uuid(),
+    teacherIds: z.uuid().array(),
+});
+
+export type SubjectCreateApiData = z.input<typeof subjectCreateApiSchema>;
+
+export const subjectEditApiSchema = z.object({
+    id: z.uuid(),
+    name: z.string().optional(),
+    teacherIds: z.uuid().array().optional(),
+});
+
+export type SubjectEditApiData = z.input<typeof subjectEditApiSchema>;

--- a/www/src/components/users/types.ts
+++ b/www/src/components/users/types.ts
@@ -1,4 +1,13 @@
+import z from 'zod';
+
 export interface UserData {
     id: string;
     name: string;
 }
+
+export const loginApiSchema = z.object({
+    email: z.string(),
+    password: z.string(),
+});
+
+export type LoginApiData = z.input<typeof loginApiSchema>;

--- a/www/src/pages/api/login.ts
+++ b/www/src/pages/api/login.ts
@@ -1,16 +1,11 @@
 import type { APIRoute } from 'astro';
-import { z } from 'zod';
 import { User } from '@backend/user';
-
-const schema = z.object({
-    email: z.string(),
-    password: z.string(),
-});
+import { loginApiSchema } from '@components/users/types';
 
 export const POST: APIRoute = async ({ locals, session }) => {
     const { jsonData } = locals;
 
-    const data = schema.nullable().catch(null).parse(jsonData);
+    const data = loginApiSchema.nullable().catch(null).parse(jsonData);
 
     if (!data) {
         return Response.json(null, { status: 400 });

--- a/www/src/pages/classrooms/api/index.ts
+++ b/www/src/pages/classrooms/api/index.ts
@@ -1,10 +1,6 @@
 import type { APIRoute } from 'astro';
-import z from 'zod';
 import { Classroom } from '@backend/classroom';
-
-const schema = z.object({
-    name: z.string().trim().nonempty(),
-});
+import { classroomCreateApiSchema, classroomEditApiSchema } from '@components/classrooms/types';
 
 export const POST: APIRoute = async ({ locals }) => {
     const { jsonData, user } = locals;
@@ -13,7 +9,7 @@ export const POST: APIRoute = async ({ locals }) => {
         return Response.json(null, { status: 404 });
     }
 
-    const data = schema.nullable().catch(null).parse(jsonData);
+    const data = classroomCreateApiSchema.nullable().catch(null).parse(jsonData);
 
     if (!data) {
         return Response.json(null, { status: 400 });
@@ -31,11 +27,6 @@ export const POST: APIRoute = async ({ locals }) => {
     return Response.json(true, { status: 201 });
 };
 
-const schemaEdit = z.object({
-    id: z.uuid(),
-    name: z.string().trim().nonempty().optional(),
-});
-
 export const PATCH: APIRoute = async ({ locals }) => {
     const { jsonData, user } = locals;
 
@@ -43,7 +34,7 @@ export const PATCH: APIRoute = async ({ locals }) => {
         return Response.json(null, { status: 404 });
     }
 
-    const data = schemaEdit.nullable().catch(null).parse(jsonData);
+    const data = classroomEditApiSchema.nullable().catch(null).parse(jsonData);
 
     if (!data) {
         return Response.json(null, { status: 400 });

--- a/www/src/pages/semesters/api/exercises.ts
+++ b/www/src/pages/semesters/api/exercises.ts
@@ -1,17 +1,9 @@
 import type { APIRoute } from 'astro';
-import { z } from 'zod';
 import { Classroom } from '@backend/classroom';
 import { Exercise } from '@backend/exercise';
 import { Subject } from '@backend/subject';
 import { User } from '@backend/user';
-
-const schema = z.object({
-    name: z.string().trim().nonempty(),
-    exerciseNumber: z.number().int().min(0),
-    subjectId: z.uuid(),
-    classroomId: z.uuid(),
-    teacherId: z.uuid(),
-});
+import { exerciseCreateApiSchema, exerciseEditApiSchema } from '@components/exercises/types';
 
 export const POST: APIRoute = async ({ locals }) => {
     const { jsonData, user } = locals;
@@ -20,7 +12,7 @@ export const POST: APIRoute = async ({ locals }) => {
         return Response.json(null, { status: 404 });
     }
 
-    const data = schema.nullable().catch(null).parse(jsonData);
+    const data = exerciseCreateApiSchema.nullable().catch(null).parse(jsonData);
 
     if (!data) {
         return Response.json(null, { status: 400 });
@@ -65,14 +57,6 @@ export const POST: APIRoute = async ({ locals }) => {
     return Response.json(true, { status: 201 });
 };
 
-const schemaEdit = z.object({
-    id: z.uuid(),
-    name: z.string().optional(),
-    exerciseNumber: z.number().optional(),
-    classroomId: z.uuid().optional(),
-    teacherId: z.uuid().optional(),
-});
-
 export const PATCH: APIRoute = async ({ locals }) => {
     const { jsonData, user } = locals;
 
@@ -80,7 +64,7 @@ export const PATCH: APIRoute = async ({ locals }) => {
         return Response.json(null, { status: 404 });
     }
 
-    const data = schemaEdit.nullable().catch(null).parse(jsonData);
+    const data = exerciseEditApiSchema.nullable().catch(null).parse(jsonData);
 
     if (!data) {
         return Response.json(null, { status: 400 });

--- a/www/src/pages/semesters/api/semesters.ts
+++ b/www/src/pages/semesters/api/semesters.ts
@@ -1,17 +1,6 @@
 import type { APIRoute } from 'astro';
-import { z } from 'zod';
 import { Semester } from '@backend/semester';
-
-const schema = z.object({
-    year: z.number(),
-    type: z.enum(['summer', 'winter']),
-    startDate: z.iso.date().transform(str => {
-        return new Date(`${str}T00:00:00`);
-    }),
-    endDate: z.iso.date().transform(str => {
-        return new Date(`${str}T00:00:00`);
-    }),
-});
+import { semesterCreateApiSchema, semesterEditApiSchema } from '@components/semesters/types';
 
 export const POST: APIRoute = async ({ locals }) => {
     const { jsonData, user } = locals;
@@ -20,7 +9,7 @@ export const POST: APIRoute = async ({ locals }) => {
         return Response.json(null, { status: 404 });
     }
 
-    const data = schema.nullable().catch(null).parse(jsonData);
+    const data = semesterCreateApiSchema.nullable().catch(null).parse(jsonData);
 
     if (!data) {
         return Response.json(null, { status: 400 });
@@ -35,24 +24,6 @@ export const POST: APIRoute = async ({ locals }) => {
     return Response.json(true, { status: 201 });
 };
 
-const schemaEdit = z.object({
-    id: z.uuid(),
-    year: z.number().optional(),
-    type: z.enum(['summer', 'winter']).optional(),
-    startDate: z.iso
-        .date()
-        .transform(str => {
-            return new Date(`${str}T00:00:00`);
-        })
-        .optional(),
-    endDate: z.iso
-        .date()
-        .transform(str => {
-            return new Date(`${str}T00:00:00`);
-        })
-        .optional(),
-});
-
 export const PATCH: APIRoute = async ({ locals }) => {
     const { jsonData, user } = locals;
 
@@ -60,7 +31,7 @@ export const PATCH: APIRoute = async ({ locals }) => {
         return Response.json(null, { status: 404 });
     }
 
-    const data = schemaEdit.nullable().catch(null).parse(jsonData);
+    const data = semesterEditApiSchema.nullable().catch(null).parse(jsonData);
 
     if (!data) {
         return Response.json(null, { status: 400 });

--- a/www/src/pages/semesters/api/subjects.ts
+++ b/www/src/pages/semesters/api/subjects.ts
@@ -1,14 +1,8 @@
 import type { APIRoute } from 'astro';
-import { z } from 'zod';
 import { Semester } from '@backend/semester';
 import { Subject } from '@backend/subject';
 import { User } from '@backend/user';
-
-const schema = z.object({
-    name: z.string().trim().nonempty(),
-    semesterId: z.uuid(),
-    teacherIds: z.uuid().array(),
-});
+import { subjectCreateApiSchema, subjectEditApiSchema } from '@components/subjects/types';
 
 export const POST: APIRoute = async ({ locals }) => {
     const { jsonData, user } = locals;
@@ -17,7 +11,7 @@ export const POST: APIRoute = async ({ locals }) => {
         return Response.json(null, { status: 404 });
     }
 
-    const data = schema.nullable().catch(null).parse(jsonData);
+    const data = subjectCreateApiSchema.nullable().catch(null).parse(jsonData);
 
     if (!data) {
         return Response.json(null, { status: 400 });
@@ -50,12 +44,6 @@ export const POST: APIRoute = async ({ locals }) => {
     return Response.json(true, { status: 201 });
 };
 
-const schemaEdit = z.object({
-    id: z.uuid(),
-    name: z.string().optional(),
-    teacherIds: z.uuid().array().optional(),
-});
-
 export const PATCH: APIRoute = async ({ locals }) => {
     const { jsonData, user } = locals;
 
@@ -63,7 +51,7 @@ export const PATCH: APIRoute = async ({ locals }) => {
         return Response.json(null, { status: 404 });
     }
 
-    const data = schemaEdit.nullable().catch(null).parse(jsonData);
+    const data = subjectEditApiSchema.nullable().catch(null).parse(jsonData);
 
     if (!data) {
         return Response.json(null, { status: 400 });


### PR DESCRIPTION
This MR adds some utils to replace `fetch` calls with. Additionally it exports types from the API body zod schemas for type checking on the frontend. `@vueuse/core` is also installed and a wrapper for `useFetch` is provided for easier reactive GET requests in future areas, like the calendar.